### PR TITLE
refactor(lacchain.system): add missing ricardian contracts

### DIFF
--- a/contracts/lacchain.system/ricardian/lacchain.system.contracts.md
+++ b/contracts/lacchain.system/ricardian/lacchain.system.contracts.md
@@ -335,8 +335,8 @@ Allows the permissioning committee to set {{ext_info}} extended information to a
 
 ---
 spec_version: "0.2.0"
-title: Set Information About an Entity
-summary: 'Set information to an {{nowrap entity}} Entity'
+title: Set Entity Information
+summary: 'Set information about an {{nowrap entity}} Entity'
 icon: @ICON_BASE_URL@/@ADMIN_ICON_URI@
 ---
 

--- a/contracts/lacchain.system/ricardian/lacchain.system.contracts.md
+++ b/contracts/lacchain.system/ricardian/lacchain.system.contracts.md
@@ -193,207 +193,207 @@ Modify, and create if necessary, the {{permission}} permission of {{account}} to
 ---
 spec_version: "0.2.0"
 title: On Error Action
-summary: 'This action is delivered to the sender of a deferred transaction'
+summary: 'This action is delivered to the {{nowrap sender}} of a deferred transaction'
 icon: @ICON_BASE_URL@/@ADMIN_ICON_URI@
 ---
 
-On error action, notification of this action is delivered to the sender of a deferred transaction
-when an objective error occurs while executing the deferred transaction.
+On error action, notification of this action is delivered to the {{sender}} of a deferred transaction {{sent_trx}} when an objective error occurs while executing the deferred transaction.
 
 <h1 class="contract">addentity</h1>
 
 ---
 spec_version: "0.2.0"
 title: Add Entity
-summary: 'Add to the network a Partner and Non Partner entity'
+summary: 'Register a partner or non-partner {{nowrap entity_name}} entity on the network'
 icon: @ICON_BASE_URL@/@ADMIN_ICON_URI@
 ---
 
-Allows the user to Add to the network a Partner and Non Partner entity.
+Allows the user to register a partner or non-partner {{nowrap entity_name}} entity on the network specifying its {{entity_type}} type and {{pubkey}} public key.
 
 <h1 class="contract">rmentity</h1>
 
 ---
 spec_version: "0.2.0"
 title: Remove Entity
-summary: 'Remove from the network a Partner and Non Partner entity'
+summary: 'Remove a partner or non-partner {{nowrap entity_name}} entity from the network'
 icon: @ICON_BASE_URL@/@ADMIN_ICON_URI@
 ---
 
-Allows the user to remove from the network a Partner and Non Partner entity.
+Allows the user to remove a partner or non-partner {{entity_name}} entity from the network.
 
 <h1 class="contract">addvalidator</h1>
 
 ---
 spec_version: "0.2.0"
-title: Add Validator
-summary: 'Add to the network a Validator for the entity'
+title: Register Validator
+summary: 'Register a {{nowrap name}} validator node on the network'
 icon: @ICON_BASE_URL@/@ADMIN_ICON_URI@
 ---
 
-Allows the user to Add to the network a Validator for the entity.
+Allows a {{entity}} partner entity to register a new {{name}} validator node on the network with its respective {{validator_authority}} authority.
 
 <h1 class="contract">addwriter</h1>
 
 ---
 spec_version: "0.2.0"
 title: Add Writer
-summary: 'Add to the network a Writer node for a Partner entity'
+summary: 'Register a {{nowrap name}} writer node on the network'
 icon: @ICON_BASE_URL@/@ADMIN_ICON_URI@
 ---
 
-Allows the user to Add to the network a Writer node for a Partner entity.
+Allows a {{entity}} partner or non-partner entity to register a new {{name}} writer node on the network with its {writer_authority}} authority.
 
 <h1 class="contract">addboot</h1>
 
 ---
 spec_version: "0.2.0"
 title: Add Boot Node
-summary: 'Add a Boot Node to the network'
+summary: 'Register a {{nowrap name}} boot node on the network'
 icon: @ICON_BASE_URL@/@ADMIN_ICON_URI@
 ---
 
-Allows the user to add a Boot Node to the network.
+Allows a {{entity}} partner entity to register a new {{name}} boot node on the network.
 
 <h1 class="contract">addobserver</h1>
 
 ---
 spec_version: "0.2.0"
 title: Add Observer Node
-summary: 'Add a Observer Node to the network'
+summary: 'Register an {{nowrap observer}} observer node on the network'
 icon: @ICON_BASE_URL@/@ADMIN_ICON_URI@
 ---
 
-Allows the user to add a Observer Node to the network.
+Allows a {{name}} partner or non-partner entity to register a new {{observer}} observer node on the network.
 
 <h1 class="contract">netaddgroup</h1>
 
 ---
 spec_version: "0.2.0"
-title: Create a Group of Nodes
-summary: 'Create a Group of Nodes to the network'
+title: Create Group of Nodes
+summary: 'Create a {{nowrap name}} group to organize {{nowrap nodes}} nodes on the network'
 icon: @ICON_BASE_URL@/@ADMIN_ICON_URI@
 ---
 
-Allows the user to add a Group of Nodes to the network.
+Allows the {{name}} permissioning committee to create a group for {{nodes}} nodes on the network.
 
 <h1 class="contract">rmnode</h1>
 
 ---
 spec_version: "0.2.0"
 title: Remove a Node
-summary: 'Remove a Node from the network'
+summary: 'Remove a {{nowrap node_name}} Node from the network'
 icon: @ICON_BASE_URL@/@ADMIN_ICON_URI@
 ---
 
-Allows the user to remove a Node from the network.
+Allows an entity to remove a {{node_name}} Node from the network.
 
 <h1 class="contract">netrmgroup</h1>
 
 ---
 spec_version: "0.2.0"
 title: Remove a Group of Nodes
-summary: 'Remove a Group of Nodes from the network'
+summary: 'Remove a {{nowrap name}} Group of Nodes from the network'
 icon: @ICON_BASE_URL@/@ADMIN_ICON_URI@
 ---
 
-Allows the user to remove a Group of Nodes from the network.
+Allows the permissioning committee to remove a {{name}} Group of Nodes from the network.
 
 <h1 class="contract">netsetgroup</h1>
 
 ---
 spec_version: "0.2.0"
 title: Link a Node
-summary: 'Link a Node with a list of Groups to the network'
+summary: 'Link a {{nowrap node}} Node with a List of Groups of the network'
 icon: @ICON_BASE_URL@/@ADMIN_ICON_URI@
 ---
 
-Allows the user to link a Node with a list of Groups to the network.
+Allows the entity nodes to link a {{node}} Node with a {{groups}} List of Groups of the network.
 
 <h1 class="contract">setnodeinfo</h1>
 
 ---
 spec_version: "0.2.0"
 title: Set Node Information
-summary: 'Set information to a Node'
+summary: 'Set information to a {{nowrap node}} Node'
 icon: @ICON_BASE_URL@/@ADMIN_ICON_URI@
 ---
 
-Allows the user to set information to a specific node.
+Allows the entity to set {{info}} information to a specific {{node}} node.
 
 <h1 class="contract">setnodexinfo</h1>
 
 ---
 spec_version: "0.2.0"
 title: Set Node Extended Information
-summary: 'Set extendend information to a Node'
+summary: 'Set extended information to a {{nowrap node}} Node'
 icon: @ICON_BASE_URL@/@ADMIN_ICON_URI@
 ---
 
-Allows the user to set extendend information to a specific node.
+Allows the permissioning committee to set {{ext_info}} extended information to a specific {{node}} node.
 
 <h1 class="contract">setentinfo</h1>
 
 ---
 spec_version: "0.2.0"
-title: Set Entity Information
-summary: 'Set information to an Entity'
+title: Set Information About an Entity
+summary: 'Set information to an {{nowrap entity}} Entity'
 icon: @ICON_BASE_URL@/@ADMIN_ICON_URI@
 ---
 
-Allows the user to set information to an entity.
+Allows an {{entity}} entity to set {{info}} information about a specific node on the network.
 
 <h1 class="contract">setentxinfo</h1>
 
 ---
 spec_version: "0.2.0"
 title: Set Extended Entity Information
-summary: 'Set extended information to an Entity'
+summary: 'Set extended information to an {{nowrap entity}} Entity'
 icon: @ICON_BASE_URL@/@ADMIN_ICON_URI@
 ---
 
-Allows the user to set extendend information to an entity.
+Allows an {{entity}} entity to set {{ext_info}} extended information such as entity name, location, and contact information.
+
 
 <h1 class="contract">setschedule</h1>
 
 ---
 spec_version: "0.2.0"
 title: Set Schedule Action
-summary: 'Set schedule action, sets a new list of active Validators'
+summary: 'Set schedule action, sets a new list of active {{nowrap validators}} Validators'
 icon: @ICON_BASE_URL@/@ADMIN_ICON_URI@
 ---
 
-Set schedule action, sets a new list of active validators, by proposing a schedule change, once the block that contains the proposal becomes irreversible, the schedule is promoted to "pending" automatically. Once the block that promotes the schedule is irreversible, the schedule will become "active".
+Set schedule action, sets a new list of active {{validators}} validators, by proposing a schedule change, once the block that contains the proposal becomes irreversible, the schedule is promoted to "pending" automatically. Once the block that promotes the schedule is irreversible, the schedule will become "active".
 
 <h1 class="contract">setram</h1>
 
 ---
 spec_version: "0.2.0"
-title: Set Ram Resource
-summary: 'Set ram resource to an account'
+title: Set RAM Resource
+summary: 'Set RAM resource to an {{nowrap account}} account from an entity'
 icon: @ICON_BASE_URL@/@ADMIN_ICON_URI@
 ---
 
-Allows the user to set ram resource to an account.
+Allows the user to set {{ram_bytes}} RAM resource to an {{account}} account from an {{entity}} entity.
 
 <h1 class="contract">onblock</h1>
 
 ---
 spec_version: "0.2.0"
 title: Effect Trigger
-summary: 'It is used for network monitoring and as an effect trigger'
+summary: 'It is used for network monitoring and as an effect trigger for each {{nowrap bh}} block'
 icon: @ICON_BASE_URL@/@ADMIN_ICON_URI@
 ---
 
-It is executed with each block and passes some data that can be used for network monitoring and as an effect trigger.
+It is executed with each {{bh}} block and passes some data that can be used for network monitoring and as an effect trigger.
 
 <h1 class="contract">reindex</h1>
 
 ---
 spec_version: "0.2.0"
 title: Dummy Action
-summary: 'I'm a dummy action!'
+summary: 'Dummy action'
 icon: @ICON_BASE_URL@/@ADMIN_ICON_URI@
 ---
 
-I'm a dummy action!.
+Dummy action for testing and development purposes.

--- a/contracts/lacchain.system/ricardian/lacchain.system.contracts.md
+++ b/contracts/lacchain.system/ricardian/lacchain.system.contracts.md
@@ -1,0 +1,399 @@
+<h1 class="contract">activate</h1>
+
+---
+spec_version: "0.2.0"
+title: Activate Protocol Feature
+summary: 'Activate protocol feature {{nowrap feature_digest}}'
+icon: @ICON_BASE_URL@/@ADMIN_ICON_URI@
+---
+
+{{$action.account}} activates the protocol feature with a digest of {{feature_digest}}.
+
+<h1 class="contract">canceldelay</h1>
+
+---
+spec_version: "0.2.0"
+title: Cancel Delayed Transaction
+summary: '{{nowrap canceling_auth.actor}} cancels a delayed transaction'
+icon: @ICON_BASE_URL@/@ACCOUNT_ICON_URI@
+---
+
+{{canceling_auth.actor}} cancels the delayed transaction with id {{trx_id}}.
+
+<h1 class="contract">deleteauth</h1>
+
+---
+spec_version: "0.2.0"
+title: Delete Account Permission
+summary: 'Delete the {{nowrap permission}} permission of {{nowrap account}}'
+icon: @ICON_BASE_URL@/@ACCOUNT_ICON_URI@
+---
+
+Delete the {{permission}} permission of {{account}}.
+
+<h1 class="contract">linkauth</h1>
+
+---
+spec_version: "0.2.0"
+title: Link Action to Permission
+summary: '{{nowrap account}} sets the minimum required permission for the {{#if type}}{{nowrap type}} action of the{{/if}} {{nowrap code}} contract to {{nowrap requirement}}'
+icon: @ICON_BASE_URL@/@ACCOUNT_ICON_URI@
+---
+
+{{account}} sets the minimum required permission for the {{#if type}}{{type}} action of the{{/if}} {{code}} contract to {{requirement}}.
+
+{{#if type}}{{else}}Any links explicitly associated to specific actions of {{code}} will take precedence.{{/if}}
+
+<h1 class="contract">newaccount</h1>
+
+---
+spec_version: "0.2.0"
+title: Create New Account
+summary: '{{nowrap creator}} creates a new account with the name {{nowrap name}}'
+icon: @ICON_BASE_URL@/@ACCOUNT_ICON_URI@
+---
+
+{{creator}} creates a new account with the name {{name}} and the following permissions:
+
+owner permission with authority:
+{{to_json owner}}
+
+active permission with authority:
+{{to_json active}}
+
+<h1 class="contract">reqactivated</h1>
+
+---
+spec_version: "0.2.0"
+title: Assert Protocol Feature Activation
+summary: 'Assert that protocol feature {{nowrap feature_digest}} has been activated'
+icon: @ICON_BASE_URL@/@ADMIN_ICON_URI@
+---
+
+Assert that the protocol feature with a digest of {{feature_digest}} has been activated.
+
+<h1 class="contract">reqauth</h1>
+
+---
+spec_version: "0.2.0"
+title: Assert Authorization
+summary: 'Assert that authorization by {{nowrap from}} is provided'
+icon: @ICON_BASE_URL@/@ACCOUNT_ICON_URI@
+---
+
+Assert that authorization by {{from}} is provided.
+
+<h1 class="contract">setabi</h1>
+
+---
+spec_version: "0.2.0"
+title: Deploy Contract ABI
+summary: 'Deploy contract ABI on account {{nowrap account}}'
+icon: @ICON_BASE_URL@/@ACCOUNT_ICON_URI@
+---
+
+Deploy the ABI file associated with the contract on account {{account}}.
+
+<h1 class="contract">setalimits</h1>
+
+---
+spec_version: "0.2.0"
+title: Adjust Resource Limits of Account
+summary: 'Adjust resource limits of account {{nowrap account}}'
+icon: @ICON_BASE_URL@/@ADMIN_ICON_URI@
+---
+
+{{$action.account}} updates {{account}}’s resource limits to have a RAM quota of {{ram_bytes}} bytes, a NET bandwidth quota of {{net_weight}} and a CPU bandwidth quota of {{cpu_weight}}.
+
+<h1 class="contract">setcode</h1>
+
+---
+spec_version: "0.2.0"
+title: Deploy Contract Code
+summary: 'Deploy contract code on account {{nowrap account}}'
+icon: @ICON_BASE_URL@/@ACCOUNT_ICON_URI@
+---
+
+Deploy compiled contract code to the account {{account}}.
+
+<h1 class="contract">setparams</h1>
+
+---
+spec_version: "0.2.0"
+title: Set System Parameters
+summary: 'Set system parameters'
+icon: @ICON_BASE_URL@/@ADMIN_ICON_URI@
+---
+
+{{$action.account}} sets system parameters to:
+{{to_json params}}
+
+<h1 class="contract">setpriv</h1>
+
+---
+spec_version: "0.2.0"
+title: Make an Account Privileged or Unprivileged
+summary: '{{#if is_priv}}Make {{nowrap account}} privileged{{else}}Remove privileged status of {{nowrap account}}{{/if}}'
+icon: @ICON_BASE_URL@/@ADMIN_ICON_URI@
+---
+
+{{#if is_priv}}
+{{$action.account}} makes {{account}} privileged.
+{{else}}
+{{$action.account}} removes privileged status of {{account}}.
+{{/if}}
+
+<h1 class="contract">setprods</h1>
+
+---
+spec_version: "0.2.0"
+title: Set Block Producers
+summary: 'Set block producer schedule'
+icon: @ICON_BASE_URL@/@ADMIN_ICON_URI@
+---
+
+{{$action.account}} proposes a block producer schedule of:
+{{#each schedule}}
+  1. {{this.producer_name}}
+{{/each}}
+
+The block signing authorities of each of the producers in the above schedule are listed below:
+{{#each schedule}}
+### {{this.producer_name}}
+{{to_json this.authority}}
+{{/each}}
+
+<h1 class="contract">unlinkauth</h1>
+
+---
+spec_version: "0.2.0"
+title: Unlink Action from Permission
+summary: '{{nowrap account}} unsets the minimum required permission for the {{#if type}}{{nowrap type}} action of the{{/if}} {{nowrap code}} contract'
+icon: @ICON_BASE_URL@/@ACCOUNT_ICON_URI@
+---
+
+{{account}} removes the association between the {{#if type}}{{type}} action of the{{/if}} {{code}} contract and its minimum required permission.
+
+{{#if type}}{{else}}This will not remove any links explicitly associated to specific actions of {{code}}.{{/if}}
+
+<h1 class="contract">updateauth</h1>
+
+---
+spec_version: "0.2.0"
+title: Modify Account Permission
+summary: 'Add or update the {{nowrap permission}} permission of {{nowrap account}}'
+icon: @ICON_BASE_URL@/@ACCOUNT_ICON_URI@
+---
+
+Modify, and create if necessary, the {{permission}} permission of {{account}} to have a parent permission of {{parent}} and the following authority:
+{{to_json auth}}
+
+<h1 class="contract">onerror</h1>
+
+---
+spec_version: "0.2.0"
+title: On Error Action
+summary: 'This action is delivered to the sender of a deferred transaction'
+icon: @ICON_BASE_URL@/@ADMIN_ICON_URI@
+---
+
+On error action, notification of this action is delivered to the sender of a deferred transaction
+when an objective error occurs while executing the deferred transaction.
+
+<h1 class="contract">addentity</h1>
+
+---
+spec_version: "0.2.0"
+title: Add Entity
+summary: 'Add to the network a Partner and Non Partner entity'
+icon: @ICON_BASE_URL@/@ADMIN_ICON_URI@
+---
+
+Allows the user to Add to the network a Partner and Non Partner entity.
+
+<h1 class="contract">rmentity</h1>
+
+---
+spec_version: "0.2.0"
+title: Remove Entity
+summary: 'Remove from the network a Partner and Non Partner entity'
+icon: @ICON_BASE_URL@/@ADMIN_ICON_URI@
+---
+
+Allows the user to remove from the network a Partner and Non Partner entity.
+
+<h1 class="contract">addvalidator</h1>
+
+---
+spec_version: "0.2.0"
+title: Add Validator
+summary: 'Add to the network a Validator for the entity'
+icon: @ICON_BASE_URL@/@ADMIN_ICON_URI@
+---
+
+Allows the user to Add to the network a Validator for the entity.
+
+<h1 class="contract">addwriter</h1>
+
+---
+spec_version: "0.2.0"
+title: Add Writer
+summary: 'Add to the network a Writer node for a Partner entity'
+icon: @ICON_BASE_URL@/@ADMIN_ICON_URI@
+---
+
+Allows the user to Add to the network a Writer node for a Partner entity.
+
+<h1 class="contract">addboot</h1>
+
+---
+spec_version: "0.2.0"
+title: Add Boot Node
+summary: 'Add a Boot Node to the network'
+icon: @ICON_BASE_URL@/@ADMIN_ICON_URI@
+---
+
+Allows the user to add a Boot Node to the network.
+
+<h1 class="contract">addobserver</h1>
+
+---
+spec_version: "0.2.0"
+title: Add Observer Node
+summary: 'Add a Observer Node to the network'
+icon: @ICON_BASE_URL@/@ADMIN_ICON_URI@
+---
+
+Allows the user to add a Observer Node to the network.
+
+<h1 class="contract">netaddgroup</h1>
+
+---
+spec_version: "0.2.0"
+title: Create a Group of Nodes
+summary: 'Create a Group of Nodes to the network'
+icon: @ICON_BASE_URL@/@ADMIN_ICON_URI@
+---
+
+Allows the user to add a Group of Nodes to the network.
+
+<h1 class="contract">rmnode</h1>
+
+---
+spec_version: "0.2.0"
+title: Remove a Node
+summary: 'Remove a Node from the network'
+icon: @ICON_BASE_URL@/@ADMIN_ICON_URI@
+---
+
+Allows the user to remove a Node from the network.
+
+<h1 class="contract">netrmgroup</h1>
+
+---
+spec_version: "0.2.0"
+title: Remove a Group of Nodes
+summary: 'Remove a Group of Nodes from the network'
+icon: @ICON_BASE_URL@/@ADMIN_ICON_URI@
+---
+
+Allows the user to remove a Group of Nodes from the network.
+
+<h1 class="contract">netsetgroup</h1>
+
+---
+spec_version: "0.2.0"
+title: Link a Node
+summary: 'Link a Node with a list of Groups to the network'
+icon: @ICON_BASE_URL@/@ADMIN_ICON_URI@
+---
+
+Allows the user to link a Node with a list of Groups to the network.
+
+<h1 class="contract">setnodeinfo</h1>
+
+---
+spec_version: "0.2.0"
+title: Set Node Information
+summary: 'Set information to a Node'
+icon: @ICON_BASE_URL@/@ADMIN_ICON_URI@
+---
+
+Allows the user to set information to a specific node.
+
+<h1 class="contract">setnodexinfo</h1>
+
+---
+spec_version: "0.2.0"
+title: Set Node Extended Information
+summary: 'Set extendend information to a Node'
+icon: @ICON_BASE_URL@/@ADMIN_ICON_URI@
+---
+
+Allows the user to set extendend information to a specific node.
+
+<h1 class="contract">setentinfo</h1>
+
+---
+spec_version: "0.2.0"
+title: Set Entity Information
+summary: 'Set information to an Entity'
+icon: @ICON_BASE_URL@/@ADMIN_ICON_URI@
+---
+
+Allows the user to set information to an entity.
+
+<h1 class="contract">setentxinfo</h1>
+
+---
+spec_version: "0.2.0"
+title: Set Extended Entity Information
+summary: 'Set extended information to an Entity'
+icon: @ICON_BASE_URL@/@ADMIN_ICON_URI@
+---
+
+Allows the user to set extendend information to an entity.
+
+<h1 class="contract">setschedule</h1>
+
+---
+spec_version: "0.2.0"
+title: Set Schedule Action
+summary: 'Set schedule action, sets a new list of active Validators'
+icon: @ICON_BASE_URL@/@ADMIN_ICON_URI@
+---
+
+Set schedule action, sets a new list of active validators, by proposing a schedule change, once the block that contains the proposal becomes irreversible, the schedule is promoted to "pending" automatically. Once the block that promotes the schedule is irreversible, the schedule will become "active".
+
+<h1 class="contract">setram</h1>
+
+---
+spec_version: "0.2.0"
+title: Set Ram Resource
+summary: 'Set ram resource to an account'
+icon: @ICON_BASE_URL@/@ADMIN_ICON_URI@
+---
+
+Allows the user to set ram resource to an account.
+
+<h1 class="contract">onblock</h1>
+
+---
+spec_version: "0.2.0"
+title: Effect Trigger
+summary: 'It is used for network monitoring and as an effect trigger'
+icon: @ICON_BASE_URL@/@ADMIN_ICON_URI@
+---
+
+It is executed with each block and passes some data that can be used for network monitoring and as an effect trigger.
+
+<h1 class="contract">reindex</h1>
+
+---
+spec_version: "0.2.0"
+title: Dummy Action
+summary: 'I'm a dummy action!'
+icon: @ICON_BASE_URL@/@ADMIN_ICON_URI@
+---
+
+I'm a dummy action!.

--- a/contracts/lacchain.system/ricardian/lacchain.system.contracts.md
+++ b/contracts/lacchain.system/ricardian/lacchain.system.contracts.md
@@ -285,7 +285,7 @@ summary: 'Remove a {{nowrap node_name}} Node from the network'
 icon: @ICON_BASE_URL@/@ADMIN_ICON_URI@
 ---
 
-Allows an entity to remove a {{node_name}} Node from the network.
+Allows an entity to remove a {{node_name}} node from the network.
 
 <h1 class="contract">netrmgroup</h1>
 
@@ -296,18 +296,18 @@ summary: 'Remove a {{nowrap name}} Group of Nodes from the network'
 icon: @ICON_BASE_URL@/@ADMIN_ICON_URI@
 ---
 
-Allows the permissioning committee to remove a {{name}} Group of Nodes from the network.
+Allows the permissioning committee to remove a {{name}} group of nodes from the network.
 
 <h1 class="contract">netsetgroup</h1>
 
 ---
 spec_version: "0.2.0"
 title: Link a Node
-summary: 'Link a {{nowrap node}} Node with a List of Groups of the network'
+summary: 'Link a {{nowrap node}} node with a list of groups of the network'
 icon: @ICON_BASE_URL@/@ADMIN_ICON_URI@
 ---
 
-Allows the entity nodes to link a {{node}} Node with a {{groups}} List of Groups of the network.
+Allows the entity nodes to link a {{node}} node with a {{groups}} list of groups of the network.
 
 <h1 class="contract">setnodeinfo</h1>
 

--- a/contracts/lacchain.system/ricardian/lacchain.system.contracts.md
+++ b/contracts/lacchain.system/ricardian/lacchain.system.contracts.md
@@ -208,7 +208,7 @@ summary: 'Register a partner or non-partner {{nowrap entity_name}} entity on the
 icon: @ICON_BASE_URL@/@ADMIN_ICON_URI@
 ---
 
-Allows the user to register a partner or non-partner {{nowrap entity_name}} entity on the network specifying its {{entity_type}} type and {{pubkey}} public key.
+Allows the user to register a partner or non-partner {{entity_name}} entity on the network specifying its {{entity_type}} type and {{pubkey}} public key.
 
 <h1 class="contract">rmentity</h1>
 
@@ -318,7 +318,7 @@ summary: 'Set information to a {{nowrap node}} Node'
 icon: @ICON_BASE_URL@/@ADMIN_ICON_URI@
 ---
 
-Allows the entity to set {{info}} information to a specific {{node}} node.
+Allows the permissioning committee to set {{info}} information to a specific {{node}} node.
 
 <h1 class="contract">setnodexinfo</h1>
 
@@ -374,7 +374,7 @@ summary: 'Set RAM resource to an {{nowrap account}} account from an entity'
 icon: @ICON_BASE_URL@/@ADMIN_ICON_URI@
 ---
 
-Allows the user to set {{ram_bytes}} RAM resource to an {{account}} account from an {{entity}} entity.
+Allows an {{entity}} entity to set {{ram_bytes}} RAM resource to an {{account}} account.
 
 <h1 class="contract">onblock</h1>
 


### PR DESCRIPTION
Update Ricardian Contract Content

## Change Description
Add new Ricardian content to:
- Warning, action `onerror` does not have a ricardian contract
- Warning, action `addentity` does not have a ricardian contract
- Warning, action `rmentity` does not have a ricardian contract
- Warning, action `addvalidator` does not have a ricardian contract
- Warning, action `addwriter` does not have a ricardian contract
- Warning, action `addboot` does not have a ricardian contract
- Warning, action `addobserver` does not have a ricardian contract
- Warning, action `netaddgroup` does not have a ricardian contract
- Warning, action `rmnode` does not have a ricardian contract
- Warning, action `netrmgroup` does not have a ricardian contract
- Warning, action `netsetgroup` does not have a ricardian contract
- Warning, action `setnodeinfo` does not have a ricardian contract
- Warning, action `setnodexinfo` does not have a ricardian contract
- Warning, action `setentinfo` does not have a ricardian contract
- Warning, action `setentxinfo` does not have a ricardian contract
- Warning, action `setschedule` does not have a ricardian contract
- Warning, action `setram` does not have a ricardian contract
- Warning, action `onblock` does not have a ricardian contract
- Warning, action `reindex` does not have a ricardian contract
